### PR TITLE
fix: allow multiple instances

### DIFF
--- a/dist/cjs/ui.js
+++ b/dist/cjs/ui.js
@@ -24,7 +24,8 @@ function addUI(instance, prefix) {
     instance.register(fastify_static_1.default, {
         root: swaggerUIRoot,
         prefix,
-        schemaHide: true
+        schemaHide: true,
+        decorateReply: false
     });
     // This hook is required because we have to serve the patched index file in order to point to the local documentation
     // eslint-disable-next-line no-useless-escape

--- a/dist/mjs/ui.mjs
+++ b/dist/mjs/ui.mjs
@@ -18,7 +18,8 @@ export function addUI(instance, prefix) {
     instance.register(fastifyStatic, {
         root: swaggerUIRoot,
         prefix,
-        schemaHide: true
+        schemaHide: true,
+        decorateReply: false
     });
     // This hook is required because we have to serve the patched index file in order to point to the local documentation
     // eslint-disable-next-line no-useless-escape

--- a/src/ui.ts
+++ b/src/ui.ts
@@ -26,7 +26,8 @@ export function addUI(instance: FastifyInstance, prefix: string): void {
   instance.register(fastifyStatic, {
     root: swaggerUIRoot,
     prefix,
-    schemaHide: true
+    schemaHide: true,
+    decorateReply: false
   })
 
   // This hook is required because we have to serve the patched index file in order to point to the local documentation

--- a/test/ui.test.ts
+++ b/test/ui.test.ts
@@ -57,5 +57,31 @@ t.test('UI serving', (t: Test) => {
     t.equal(defaultBody, indexBody)
   })
 
+  t.test('should allow multiple instances', async (t: Test) => {
+    const server = fastify()
+
+    server.register(fastifyOpenApiDocs, { prefix: 'v1' })
+    server.register(fastifyOpenApiDocs, { prefix: 'v2' })
+
+    const { statusCode: redirectStatus, body: redirectBody } = await server.inject('/v1')
+    const { body: defaultBody } = await server.inject('/v1/')
+    const { body: indexBody } = await server.inject('/v1/index.html')
+
+    const { statusCode: redirectStatusv2, body: redirectBodyv2 } = await server.inject('/v2')
+    const { body: defaultBodyv2 } = await server.inject('/v2/')
+    const { body: indexBodyv2 } = await server.inject('/v2/index.html')
+
+    t.equal(redirectStatus, 301)
+    t.equal(redirectBody, '')
+    t.true(defaultBody.indexOf('url: "/v1/openapi.json",') > 0)
+    t.true(indexBody.indexOf('url: "/v1/openapi.json",') > 0)
+    t.equal(defaultBody, indexBody)
+    t.equal(redirectStatusv2, 301)
+    t.equal(redirectBodyv2, '')
+    t.true(defaultBodyv2.indexOf('url: "/v2/openapi.json",') > 0)
+    t.true(indexBodyv2.indexOf('url: "/v2/openapi.json",') > 0)
+    t.equal(defaultBodyv2, indexBodyv2)
+  })
+
   t.end()
 })


### PR DESCRIPTION
Remove fastify-static decorator to allow multiple openapi-docs instances in different paths

Closes #1